### PR TITLE
Update to 5.1.1 API

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -64,23 +64,23 @@ function update_light_player(pinfo)
 	end
 	
 	for h,p in pairs(adds) do
-		local node = minetest.env:get_node_or_nil(p)
+		local node = minetest.get_node_or_nil(p)
 		if node == nil or (node ~= nil and node.name == "air") then
-			minetest.env:add_node(p, {type="node",name="walking_light:light"})
+			minetest.add_node(p, {type="node",name="walking_light:light"})
 		end
 	end
 
 	for h,p in pairs(removes) do
-		local node = minetest.env:get_node_or_nil(p)
+		local node = minetest.get_node_or_nil(p)
 		if node ~= nil and node.name == "walking_light:light" then
-			minetest.env:add_node(p, {type="node",name="air"})
+			minetest.add_node(p, {type="node",name="air"})
 		end
 	end
 end
 
 function update_light_all(dtime)
 	for name,pinfo in pairs(players) do
-		local pos = pinfo.mt_player:getpos()
+		local pos = pinfo.mt_player:get_pos()
 		pinfo.wielded = pinfo.wielding
 		pinfo.wielding = wielding_light(pinfo)
 		if pos ~= nil then

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,4 @@
-local wielding_only = false
+local wielding_only = minetest.settings:get_bool("walking_light.wielding_only", false)
 
 local players = {}
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,2 @@
+#   If enabled light sources will only emit light when wielded
+walking_light.wielding_only (Wielding Only) bool false


### PR DESCRIPTION
I've been using your mod for years. Well, actually I took a break from Minetest for a while while focusing on school. But, I'm back!

Since 0.4.7, minetest.env is deprecated. The first commit in this pull request handles that. (And also updates getpos to get_pos).

The second commit exposes the wielding_only option to the Minetest settings interface, so that it can be toggled without having to edit the code.